### PR TITLE
Removed version and change dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "antoniocarboni/magento2-traduzione-italiana",
     "description": " Magento2 Italian Language Pack (it_IT) ",
     "homepage": "https://github.com/antoniocarboni/magento2-traduzione-italiana",
-    "version": "100.0.4",
     "license": [
         "OSL-3.0"
     ],
@@ -17,7 +16,7 @@
         }
     ],
     "require": {
-        "magento/framework": "100.0.*"
+        "magento/framework": "100.*"
     },
     "type": "magento2-language",
     "autoload": {


### PR DESCRIPTION
Removed version for packagist/toran proxy/packagist 
Change dependency magento2-framework to let it work with magento 2.1
