### PR TITLE
Generic version constraints (solves #10)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "magento/framework": "100.*"
+        "magento/framework": "*"
     },
     "type": "magento2-language",
     "autoload": {


### PR DESCRIPTION
I've set magento dependency version constraint in `require` section to a generic * so it works with every magento version. Even if incomplete still better than not having translation at all.