### PR TITLE
Fix vendor name on language.xml

### DIFF
--- a/language.xml
+++ b/language.xml
@@ -6,7 +6,7 @@
 
 <language xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/Language/package.xsd">
     <code>it_IT</code>
-    <vendor>itfm</vendor>
+    <vendor>itformage</vendor>
     <package>it_it</package>
     <sort_order>100</sort_order>
 </language>


### PR DESCRIPTION
Ciao ragazzi, ciao @WaPoNe ,

Propongo questa pull request che va a fare revert dell'[ultimo commit](https://github.com/it4mage/magento2-traduzione-italiana/commit/359c73432ad1188e36b86363d7822ffcaf70f873).

Il framework cerca la traduzione su un language pack registrato con la seguente convenzione:
`strtolower($vendor . '_' . $package)`

Il modulo è registrato come `itformage_it_it`, ma su language.xml il vendor è `itfm`. Di conseguenza il file csv non è caricato tra le traduzioni, ed è probabilmente la root cause della [issue 15](https://github.com/it4mage/magento2-traduzione-italiana/issues/15).

Ho mantenuto _itformage_ invece che _itfm_ seguendo il commento di @giuseppemorelli in [questa PR](https://github.com/it4mage/magento2-traduzione-italiana/pull/16).

Grazie,
Renato